### PR TITLE
feat(recording): Add maxSeconds param in startRecording

### DIFF
--- a/static/api/v1.yaml
+++ b/static/api/v1.yaml
@@ -1942,7 +1942,14 @@ components:
           description: >-
             (Beta) Change the recording to record this specific URL for this meeting.
             Only enabled for specific organizations. A valid https:// url is needed.
-          example: tree
+          example: 'https://dyte.io'
+        maxSeconds:
+          type: number
+          description: >-
+            The max duration after which the recording will automatically be stopped. By default, this value is
+            10800 seconds (3 hours). The minimum value is 1 second, and the maximum value is 86400 seconds (24 hours).
+          example: 300
+
     UpdateRecordingRequestBody:
       type: object
       properties:


### PR DESCRIPTION
## Description

Add the maxSeconds param in the startRecording endpoint

[CORE-218]

## Resolved issues

Closes #1

### Before submitting the PR, please take the following into consideration
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [X] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [X] The description should clearly illustrate what problems it solves.
- [X] Ensure that the commit messages follow our guidelines.
- [X] Resolve merge conflicts (if any).
- [X] Make sure that the current branch is upto date with the `main` branch.


[CORE-218]: https://dyte-io.atlassian.net/browse/CORE-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ