### PR TITLE
fix(navbar/index.js): add the missing inclusion of NEW_MOBILE_SDKS in…

### DIFF
--- a/src/theme/Navbar/index.js
+++ b/src/theme/Navbar/index.js
@@ -35,7 +35,7 @@ import { Github } from '@styled-icons/boxicons-logos';
 import { DiscordIcon } from '../../assets/icons';
 import ThemeSwitcher from '@site/src/components/ThemeSwitcher';
 import SearchBar from '@theme/SearchBar';
-import { NON_UI_SDKS, PREBUILT_SDKS, UI_SDKS } from '../../utils/constants';
+import { NEW_MOBILE_SDKS, NON_UI_SDKS, PREBUILT_SDKS, UI_SDKS } from '../../utils/constants';
 import Quickstart from '../../components/Quickstart';
 
 function useNavbarItems() {
@@ -227,6 +227,8 @@ const getPage = () => {
         return 'prebuilt-sdks';
       } else if (UI_SDKS.concat(NON_UI_SDKS).includes(doc)) {
         return 'web-sdks';
+      } else if(NEW_MOBILE_SDKS.includes(doc)) {
+        return 'mobile-sdks'
       }
       return null;
   }


### PR DESCRIPTION

Navbar component didn't returned the mobile-sdks string for validation of the active component
inside the navbar.

## Description

The mobile-sdks string was not returned by the defaults in the getPage method which made the validation for the active navbar component as null and as result the Mobile SDKs remained default color. This PR added the check for the doc with the constants NEW_MOBILE_SDKS and returns mobile-sdks on true.

