### PR TITLE
fix(docs): Fix yarn installation command in react UI kit installation.mdx

### DIFF
--- a/react-ui-kit_versioned_docs/version-0.2/installation.mdx
+++ b/react-ui-kit_versioned_docs/version-0.2/installation.mdx
@@ -41,7 +41,7 @@ npm install @dytesdk/react-ui-kit @dytesdk/react-web-core
 Install the package from yarn:
 
 ```bash
-yarn @dytesdk/react-ui-kit @dytesdk/react-web-core
+yarn add @dytesdk/react-ui-kit @dytesdk/react-web-core
 ```
 
 </TabItem>


### PR DESCRIPTION
Fix yarn installation command for react-ui-kit

## Description

The command `yarn @dytesdk/react-ui-kit @dytesdk/react-web-core` missing `add` command inside React ui kit installation page.

## Resolved issues

Closes #1

### Before submitting the PR, please take the following into consideration
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.
