### PR TITLE
docs: fix typo & add Atomic Design blog post link

### DIFF
--- a/docs/ui-kit/basics/atomic-design.mdx
+++ b/docs/ui-kit/basics/atomic-design.mdx
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Atomic Design
 
-Inspired by Atomic Design pricinciples, our UI Kit is built in layers.
+Inspired by [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) principles, our UI Kit is built in layers.
 
 What that means is you can quickly get started by using just one component and keep combining even more components that will give you an entire prebuilt UI.
 


### PR DESCRIPTION
I noticed a typo while reading. Also, I had never heard of Atomic Design. I figured a link would be helpful.