### PR TITLE
Fixing the descriptions for videoTrack and rawVideoTrack.

### DIFF
--- a/docs/web-core/local-user/introduction.mdx
+++ b/docs/web-core/local-user/introduction.mdx
@@ -38,11 +38,9 @@ Here is a list of properties that local user provides:
 - `mediaPermissions`: The current audio and video permissions given by the local
   user.
 - `audioTrack`: The audio track for the local user.
-- `rawAudioTrack`: The audio track for the local user without any middleware
-  applied on it.
-- `videoTrack`: The video track for the local user without any middleware
-  applied on it.
-- `rawVideoTrack`: The video track for the local user.
+- `rawAudioTrack`: The audio track for the local user without any middleware applied on it.
+- `videoTrack`: The video track for the local user.
+- `rawVideoTrack`: The video track for the local user without any middleware applied on it.
 - `screenShareTracks`: The screen share video and audio tracks for the local
   user.
 - `audioEnabled`: A boolean value indicating if the audio currently enabled.


### PR DESCRIPTION
## Description

Fixing the descriptions for `videoTrack` and `rawVideoTrack` for the web core local user properties.
